### PR TITLE
Refactor file name processing functions

### DIFF
--- a/capstone/scripts/helpers.py
+++ b/capstone/scripts/helpers.py
@@ -341,42 +341,33 @@ class HashingFile:
     def __getattr__(self, attr):
         return getattr(self._source, attr)
 
-def id_from_s3_key(s3_key):
-    return s3_key.split('/')[-1].split('.')[0]\
-        .replace('unredacted', 'redacted')\
-        .replace('_redacted', '')\
-        .replace('_ALTO', '')\
-        .replace('CASEMETS', '')
+def case_or_page_barcode_from_s3_key(input):
+    """
+        Transform s3 keys to case or page barcodes:
+            32044142600386_redacted/alto/32044142600386_redacted_ALTO_00009_0.xml  ->  32044142600386_00009_0
+            32044142600386_redacted/casemets/32044142600386_redacted_CASEMETS_0001.xml  -> 32044142600386_0001
+    """
+    if ('CASEMETS' in input or 'ALTO' in input) and input.endswith("xml"):
+        return input.split('/')[-1].split('.')[0]\
+            .replace('unredacted', 'redacted')\
+            .replace('_redacted_ALTO', '')\
+            .replace('_redacted_CASEMETS', '')
+    raise Exception("Not an ALTO or CASEMETS s3_key")
 
 def short_id_from_s3_key(input):
-    """Gives you a short ID from an ALTO or CASEMETS s3_key"""
+    """
+        Transform s3 keys to case or page short IDs used by volume XML:
+            32044142600386_redacted/alto/32044142600386_redacted_ALTO_00009_0.xml  ->  alto_00009_0
+            32044142600386_redacted/casemets/32044142600386_redacted_CASEMETS_0001.xml  -> casemets_0001
+    """
     if ('CASEMETS' in input or 'ALTO' in input) and input.endswith("xml"):
         return input.split('/')[-1].split('.')[0].split('redacted_')[1].lower()
     raise Exception("Not an ALTO or CASEMETS s3_key")
-
-def alto_barcode_from_s3_key(input):
-    """Gives you a short ID from an ALTO or CASEMETS s3_key"""
-    if ('CASEMETS' in input or 'ALTO' in input) and input.endswith("xml"):
-        return input.split('/')[-1].split('.')[0].split('redacted_')[1].lower()
-    raise Exception("Not an ALTO or CASEMETS s3_key")
-
-def short_id_from_alto_barcode(barcode):
-    """Gives you a short ID from an s3_key"""
-    if len(barcode.split('_')) == 3:
-        return "alto_" + barcode.split('_', 1)[1]
-    elif len(barcode.split('_')) == 4:
-        return "alto_" + barcode.split('_', 2)[2]
-    raise Exception("Unknown ALTO ID Format: {}".format(barcode))
-
-def short_id_from_case_id(case_id):
-    """Gives you a short ID from an s3_key"""
-    """ ID of this case as referred to by volume xml file. """
-    if len(case_id.split('_')) == 2:
-        return "casemets_" + case_id.split('_', 1)[1]
-    elif len(case_id.split('_')) == 3:
-        return "casemets_" + case_id.split('_', 2)[2]
-    else:
-        raise Exception("Unknown Case ID Format: {}".format(case_id))
 
 def volume_barcode_from_folder(folder):
-    return folder.replace('unredacted', 'redacted').replace("_redacted","")
+    """
+        Transform folder name to barcode:
+            Cal4th_063_redacted  ->  Cal4th_063
+            32044032501660_unredacted_2018_10_18_06.26.00  ->  32044032501660
+    """
+    return folder.replace('unredacted', 'redacted').split("_redacted", 1)[0]

--- a/capstone/scripts/ingest_by_manifest.py
+++ b/capstone/scripts/ingest_by_manifest.py
@@ -17,7 +17,7 @@ from django.utils.encoding import force_str
 from capdb.models import VolumeXML, PageXML, CaseXML, VolumeMetadata
 from capdb.storages import get_storage, ingest_storage, redis_ingest_client as r
 from scripts.helpers import (resolve_namespace, parse_xml, volume_barcode_from_folder,
-    id_from_s3_key)
+                             case_or_page_barcode_from_s3_key)
 from scripts.process_ingested_xml import build_case_page_join_table
 
 logger = get_task_logger(__name__)
@@ -295,7 +295,7 @@ def ingest_volume(volume_folder, s3_items_by_type):
                           volume.case_xmls.select_related('metadata').defer('orig_xml')}
         for case_s3_key, case_md5 in s3_items_by_type['casemets']:
 
-            case = existing_cases.pop(id_from_s3_key(case_s3_key), None)
+            case = existing_cases.pop(case_or_page_barcode_from_s3_key(case_s3_key), None)
 
             # handle existing case
             if case:
@@ -318,7 +318,7 @@ def ingest_volume(volume_folder, s3_items_by_type):
 
         existing_pages = {p.barcode: p for p in volume.page_xmls.defer('orig_xml')}
         for page_s3_key, page_md5 in s3_items_by_type['alto']:
-            alto_barcode = id_from_s3_key(page_s3_key)
+            alto_barcode = case_or_page_barcode_from_s3_key(page_s3_key)
 
             page = existing_pages.pop(alto_barcode, None)
 


### PR DESCRIPTION
Some suggestions for the filename processing functions in your PR:

- rename `id_from_s3_key` to `case_or_page_barcode_from_s3_key`
- drop unused functions `short_id_from_alto_barcode` and `short_id_from_case_id` (which could be simplified if kept, but I'm not sure we need them)
- add examples of data in/out for each function
- logic tweak: `id_from_s3_key` was leaving an extra underscore in CASEMETS inputs
- logic tweak: `volume_barcode_from_folder` needs to strip dates from folder names that have them