### PR TITLE
Pin pip to 19.2.3

### DIFF
--- a/capstone/Dockerfile
+++ b/capstone/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update \
 RUN mkdir /app
 WORKDIR /app
 COPY requirements.txt /app
-RUN pip install -U pip \
+RUN pip install pip==19.2.3 \
     && pip install -r requirements.txt --src /usr/local/src \
     && rm requirements.txt
 

--- a/capstone/docker-compose.yml
+++ b/capstone/docker-compose.yml
@@ -35,7 +35,7 @@ services:
           - 9200:9200
     worker:
         build: .
-        image: capstone:0.3.48-f7a13208fd5a61a61250c559e56c19c3
+        image: capstone:0.3.49-0ef65497de943605c700b799959c10fa
         volumes:
             # NAMED VOLUMES
             # Use a named, persistent volume so that the node_modules directory,
@@ -62,7 +62,7 @@ services:
           - "api.case.test:127.0.0.1"
     web:
         build: .
-        image: capstone:0.3.48-f7a13208fd5a61a61250c559e56c19c3
+        image: capstone:0.3.49-0ef65497de943605c700b799959c10fa
         volumes:
             # NAMED VOLUMES
             - node_modules:/app/node_modules:delegated


### PR DESCRIPTION
The problem (a failure to run `fab pip-compile` in `capdb/tests/test_build.py`) has to do with pip 19.3, which came out yesterday; see https://stackoverflow.com/questions/58386140/attributeerror-module-pip-internal-download-has-no-attribute-httpadapter which isn't exactly our problem (`AttributeError: module 'pip._internal.download' has no attribute 'is_file_url'`), but similar.